### PR TITLE
With the release of puppet-lint 2.0.0, support ~>2.0 versions.

### DIFF
--- a/puppet-lint-appends-check.gemspec
+++ b/puppet-lint-appends-check.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name        = 'puppet-lint-appends-check'
-  spec.version     = '0.1.0'
+  spec.version     = '0.2.0'
   spec.homepage    = 'https://github.com/puppet-community/puppet-lint-appends-check'
   spec.license     = 'Apache-2.0'
   spec.author      = 'Puppet Community'
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
     A puppet-lint plugin to check that the appends operator (+=) is not used (removed in Puppet 4.0.0).
   EOF
 
-  spec.add_dependency             'puppet-lint', '~> 1.0'
+  spec.add_dependency             'puppet-lint', '~> 2.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rspec-its', '~> 1.0'
   spec.add_development_dependency 'rspec-collection_matchers', '~> 1.0'


### PR DESCRIPTION
Many people are using puppet-lint from git head, and have been for a while. puppet-lint 2.0.0 was published today, with no actual changes other than the version number, but it breaks checks that specified `~>1.0`.
